### PR TITLE
Rename repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /go/src/app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN go build -ldflags="-X 'github.com/kanopy-platform/multi-arch-images/internal/version.version=${VERSION}' -X 'github.com/kanopy-platform/multi-arch-images/internal/version.gitCommit=${GIT_COMMIT}'" -o /go/bin/app ./cmd/
+RUN go build -ldflags="-X 'github.com/kanopy-platform/buildah-plugin/internal/version.version=${VERSION}' -X 'github.com/kanopy-platform/buildah-plugin/internal/version.gitCommit=${GIT_COMMIT}'" -o /go/bin/app ./cmd/
 
 FROM debian:buster-slim
 RUN groupadd -r app && useradd --no-log-init -r -g app app

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ local:
 	${CONTAINER_RUNTIME} build --build-arg GIT_COMMIT=${GIT_COMMIT} -t $(CMD_NAME):latest .
 
 .PHONY: local-run
-local-run: local ## Build and run the application in a local docker container
+local-run: local ## Build and run the application in a local container
 	${CONTAINER_RUNTIME} push ${REGISTRY_NAME}/$(CMD_NAME):latest --tls-verify=${TLS_VERIFY}
 	${CONTAINER_RUNTIME} run $(CMD_NAME):latest
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # buildah-plugin
-This is a Drone compatible plugin that executes [Buildah](https://github.com/containers/buildah) commands.
+This is a Drone compatible plugin that executes [buildah](https://github.com/containers/buildah) commands.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# multi-arch-images
-This is a tool that assembles an OCI compliant manifest from the architecture specific images (amd64, arm64) built for an application. This allows the resulting single image to support multiple architectures.
+# buildah-plugin
+This is a Drone compatible plugin that executes [Buildah](https://github.com/containers/buildah) commands.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kanopy-platform/multi-arch-images
+module github.com/kanopy-platform/buildah-plugin
 
 go 1.20
 


### PR DESCRIPTION
I mistakenly named the repo `multi-arch-images` previously.
Updating the name to `buildah-plugin` which actually fits its use.

Drone builds are working with new name. I will delete the ECR repo [multi-arch-images](https://gallery.ecr.aws/kanopy/multi-arch-images) once this is merged.