### PR TITLE
Add ECR credential provider

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -12,7 +12,7 @@ def main(ctx):
 
     resources = {"requests": {"cpu": 400, "memory": "2Gi"}}
 
-    trigger = {"branch": ["main", "ecr_auth"]}
+    trigger = {"branch": ["main"]}
 
     test_steps = {
         "test": append_volumes(test_step(), volumes),

--- a/.drone.star
+++ b/.drone.star
@@ -73,13 +73,15 @@ def build(name, arch, tag, publish):
         "pull": "always",
         "environment": {
             "GIT_COMMIT": "${DRONE_COMMIT_SHA:0:7}",
+            "PLUGIN_TYPE": "drone",
+            "ARCH": arch,
         },
         "settings": {
             "repo": "${DRONE_REPO_NAME}",
             "build_args": [
                 "GIT_COMMIT",
                 "PLUGIN_TYPE",
-                "ARCH": arch,
+                "ARCH",
             ],
             "tags": [
                 "git-${DRONE_COMMIT_SHA:0:7}-" + arch,

--- a/.drone.star
+++ b/.drone.star
@@ -12,7 +12,7 @@ def main(ctx):
 
     resources = {"requests": {"cpu": 400, "memory": "2Gi"}}
 
-    trigger = {"branch": ["main"]}
+    trigger = {"branch": ["main", "ecr_auth"]}
 
     test_steps = {
         "test": append_volumes(test_step(), volumes),
@@ -52,7 +52,7 @@ def main(ctx):
         pipe["steps"].append(bsnp)
 
         bs = build("publish", plat, False, True)
-        bs = set_when(bs, {"event": ["pull_request"]})
+        bs = set_when(bs, {"event": ["push"]})
         bs = append_depends_on(bs, test_steps.keys())
         bs = append_volumes(bs, volumes)
         pipe["steps"].append(bs)

--- a/.drone.star
+++ b/.drone.star
@@ -12,8 +12,6 @@ def main(ctx):
 
     resources = {"requests": {"cpu": 400, "memory": "2Gi"}}
 
-    trigger = {"branch": ["main"]}
-
     test_steps = {
         "test": append_volumes(test_step(), volumes),
     }
@@ -75,13 +73,13 @@ def build(name, arch, tag, publish):
         "pull": "always",
         "environment": {
             "GIT_COMMIT": "${DRONE_COMMIT_SHA:0:7}",
-            "PLUGIN_TYPE": "drone",
         },
         "settings": {
             "repo": "${DRONE_REPO_NAME}",
             "build_args": [
                 "GIT_COMMIT",
                 "PLUGIN_TYPE",
+                "ARCH": arch,
             ],
             "tags": [
                 "git-${DRONE_COMMIT_SHA:0:7}-" + arch,

--- a/.drone.star
+++ b/.drone.star
@@ -12,6 +12,8 @@ def main(ctx):
 
     resources = {"requests": {"cpu": 400, "memory": "2Gi"}}
 
+    trigger = {"branch": ["**/*"]}
+
     test_steps = {
         "test": append_volumes(test_step(), volumes),
     }

--- a/.drone.star
+++ b/.drone.star
@@ -52,7 +52,7 @@ def main(ctx):
         pipe["steps"].append(bsnp)
 
         bs = build("publish", plat, False, True)
-        bs = set_when(bs, {"event": ["push"]})
+        bs = set_when(bs, {"event": ["pull_request"]})
         bs = append_depends_on(bs, test_steps.keys())
         bs = append_volumes(bs, volumes)
         pipe["steps"].append(bs)

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,6 @@ ENV HOME=/buildah
 RUN mkdir -m 777 -p $HOME/.docker
 RUN chown -R app $HOME
 USER app
-COPY --from=build /go/bin/app /
 COPY --from=build /go/bin/docker-credential-ecr-login /usr/bin/
+COPY --from=build /go/bin/app /
 ENTRYPOINT ["/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,18 +7,24 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN go build -ldflags="-X 'github.com/kanopy-platform/buildah-plugin/internal/version.version=${VERSION}' -X 'github.com/kanopy-platform/buildah-plugin/internal/version.gitCommit=${GIT_COMMIT}' -X 'github.com/kanopy-platform/buildah-plugin/internal/version.pluginType=${PLUGIN_TYPE}'" -o /go/bin/app ./cmd/
-RUN go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@latest
+
+FROM debian:bookworm-slim as ecr-login
+ARG ECR_LOGIN_VERSION="0.7.1"
+ARG ARCH="amd64"
+RUN apt-get update && apt-get install -y wget
+RUN wget -O /docker-credential-ecr-login https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/${ECR_LOGIN_VERSION}/linux-${ARCH}/docker-credential-ecr-login
+RUN chmod +x /docker-credential-ecr-login
 
 FROM quay.io/buildah/stable:v1.31.0
 RUN groupadd -r app && useradd --no-log-init -r -g app app
 # Add ranges needed for buildah commands
-RUN echo app:10000:65536 >> /etc/subuid
-RUN echo app:10000:65536 >> /etc/subgid
+# RUN usermod --add-subuids 10000-65536 app
+# RUN usermod --add-subgids 10000-65536 app
 # Create directory needed to store credentials
 ENV HOME=/buildah
 RUN mkdir -m 777 -p $HOME/.docker
 RUN chown -R app $HOME
 USER app
-COPY --from=build /go/bin/docker-credential-ecr-login /usr/bin/
+COPY --from=ecr-login /docker-credential-ecr-login /usr/bin/
 COPY --from=build /go/bin/app /
 ENTRYPOINT ["/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,15 +16,8 @@ RUN wget -O /docker-credential-ecr-login https://amazon-ecr-credential-helper-re
 RUN chmod +x /docker-credential-ecr-login
 
 FROM quay.io/buildah/stable:v1.31.0
-RUN groupadd -r app && useradd --no-log-init -r -g app app
-# Add ranges needed for buildah commands
-# RUN usermod --add-subuids 10000-65536 app
-# RUN usermod --add-subgids 10000-65536 app
-# Create directory needed to store credentials
-ENV HOME=/buildah
-RUN mkdir -m 777 -p $HOME/.docker
-RUN chown -R app $HOME
-USER app
+USER build
+RUN mkdir -p /home/build/.docker
 COPY --from=ecr-login /docker-credential-ecr-login /usr/bin/
 COPY --from=build /go/bin/app /
 ENTRYPOINT ["/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,18 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN go build -ldflags="-X 'github.com/kanopy-platform/buildah-plugin/internal/version.version=${VERSION}' -X 'github.com/kanopy-platform/buildah-plugin/internal/version.gitCommit=${GIT_COMMIT}' -X 'github.com/kanopy-platform/buildah-plugin/internal/version.pluginType=${PLUGIN_TYPE}'" -o /go/bin/app ./cmd/
+RUN go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@latest
 
 FROM quay.io/buildah/stable:v1.31.0
 RUN groupadd -r app && useradd --no-log-init -r -g app app
+# Add ranges needed for buildah commands
+RUN echo app:10000:65536 >> /etc/subuid
+RUN echo app:10000:65536 >> /etc/subgid
+# Create directory needed to store credentials
+ENV HOME=/buildah
+RUN mkdir -m 777 -p $HOME/.docker
+RUN chown -R app $HOME
 USER app
 COPY --from=build /go/bin/app /
+COPY --from=build /go/bin/docker-credential-ecr-login /usr/bin/
 ENTRYPOINT ["/app"]

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ GO_MODULE := $(shell git config --get remote.origin.url | grep -o 'github\.com[:
 CMD_NAME := $(shell basename ${GO_MODULE})
 GIT_COMMIT := $(shell git rev-parse HEAD)
 PLUGIN_TYPE ?= drone
+ARCH ?= "amd64"
 REGISTRY_NAME ?= registry.example.com
 CONTAINER_RUNTIME ?= docker
 

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,12 @@ tidy:
 local:
 	${CONTAINER_RUNTIME} build --build-arg GIT_COMMIT=${GIT_COMMIT} --build-arg PLUGIN_TYPE=${PLUGIN_TYPE} -t ${REGISTRY_NAME}/$(CMD_NAME):latest .
 
-.PHONY: local-run
-local-run: local ## Build and run the application in a local container
+.PHONY: local-push
+local-push: local
 	${CONTAINER_RUNTIME} push ${REGISTRY_NAME}/$(CMD_NAME):latest
+
+.PHONY: local-run
+local-run: local-push ## Build and run the application in a local container
 	${CONTAINER_RUNTIME} run ${REGISTRY_NAME}/$(CMD_NAME):latest
 
 .PHONY: help

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
-	github.com/stretchr/testify v1.8.3
+	github.com/stretchr/testify v1.8.4
 )
 
 require (
@@ -23,7 +23,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
-	golang.org/x/sys v0.8.0 // indirect
+	golang.org/x/sys v0.10.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,9 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -314,8 +315,8 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
-golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	buildversion "github.com/kanopy-platform/buildah-plugin/internal/version"
 	"github.com/kanopy-platform/buildah-plugin/pkg/buildah"
+	"github.com/kanopy-platform/buildah-plugin/pkg/ecr"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -61,14 +63,25 @@ func (c *RootCommand) persistentPreRunE(cmd *cobra.Command, args []string) error
 }
 
 func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
-	// TODO get password from AWS ECR provider
+	dockerConfig, err := ecr.CreateDockerConfig(
+		viper.GetString("access-key"),
+		viper.GetString("secret-key"),
+		viper.GetString("registry"),
+	)
+	if err != nil {
+		return err
+	}
+
+	jsonBytes, err := json.Marshal(dockerConfig)
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile("/buildah/.docker/config.json", jsonBytes, 0600); err != nil {
+		return err
+	}
 
 	buildah := buildah.Buildah{
-		Login: buildah.Login{
-			Registry: viper.GetString("registry"),
-			Username: "AWS",      // TODO use output from AWS ECR provider
-			Password: "password", // TODO use output from AWS ECR provider
-		},
 		Repo: viper.GetString("repo"),
 	}
 

--- a/pkg/buildah/buildah.go
+++ b/pkg/buildah/buildah.go
@@ -12,16 +12,9 @@ import (
 
 type (
 	Buildah struct {
-		Login    Login // configuration for "buildah login"
 		Repo     string
 		Version  version.CommandArgs
 		Manifest manifest.CommandArgs
-	}
-
-	Login struct {
-		Registry string
-		Username string
-		Password string
 	}
 )
 

--- a/pkg/buildah/manifest/manifest.go
+++ b/pkg/buildah/manifest/manifest.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-
-	"github.com/kanopy-platform/buildah-plugin/pkg/buildah/common"
 )
 
 const (
@@ -31,13 +29,7 @@ func (c *CommandArgs) GetCmds() ([]*exec.Cmd, error) {
 		return cmds, nil
 	}
 
-	// TODO replace with actual manifest commands. Currently is just testing that credentials work.
-	cmds = append(cmds,
-		exec.Command(common.BuildahCmd, "manifest", "create", "--storage-driver=vfs", "public.ecr.aws/kanopy/buildah-plugin:multiarchtest2"),
-		exec.Command(common.BuildahCmd, "manifest", "add", "--storage-driver=vfs", "public.ecr.aws/kanopy/buildah-plugin:multiarchtest2", "public.ecr.aws/kanopy/buildah-plugin:git-3afa39c-arm64"),
-		exec.Command(common.BuildahCmd, "manifest", "add", "--storage-driver=vfs", "public.ecr.aws/kanopy/buildah-plugin:multiarchtest2", "public.ecr.aws/kanopy/buildah-plugin:git-3afa39c-amd64"),
-		exec.Command(common.BuildahCmd, "manifest", "push", "--storage-driver=vfs", "--all", "public.ecr.aws/kanopy/buildah-plugin:multiarchtest2"),
-	)
+	// TODO add commands to run.
 
 	return cmds, nil
 }

--- a/pkg/buildah/manifest/manifest.go
+++ b/pkg/buildah/manifest/manifest.go
@@ -33,7 +33,10 @@ func (c *CommandArgs) GetCmds() ([]*exec.Cmd, error) {
 
 	// TODO replace with actual manifest commands. Currently is just testing that credentials work.
 	cmds = append(cmds,
-		exec.Command(common.BuildahCmd, "pull", c.Sources[0]),
+		exec.Command(common.BuildahCmd, "manifest", "create", "public.ecr.aws/kanopy/buildah-plugin:multiarchtest2"),
+		exec.Command(common.BuildahCmd, "manifest", "add", "public.ecr.aws/kanopy/buildah-plugin:multiarchtest2", "public.ecr.aws/kanopy/buildah-plugin:git-3afa39c-arm64"),
+		exec.Command(common.BuildahCmd, "manifest", "add", "public.ecr.aws/kanopy/buildah-plugin:multiarchtest2", "public.ecr.aws/kanopy/buildah-plugin:git-3afa39c-amd64"),
+		exec.Command(common.BuildahCmd, "manifest", "push", "--all", "public.ecr.aws/kanopy/buildah-plugin:multiarchtest2"),
 	)
 
 	return cmds, nil

--- a/pkg/buildah/manifest/manifest.go
+++ b/pkg/buildah/manifest/manifest.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+
+	"github.com/kanopy-platform/buildah-plugin/pkg/buildah/common"
 )
 
 const (
@@ -29,7 +31,10 @@ func (c *CommandArgs) GetCmds() ([]*exec.Cmd, error) {
 		return cmds, nil
 	}
 
-	// TODO add commands to run
+	// TODO replace with actual manifest commands. Currently is just for testing credentials work.
+	cmds = append(cmds,
+		exec.Command(common.BuildahCmd, "pull", c.Sources[0]),
+	)
 
 	return cmds, nil
 }

--- a/pkg/buildah/manifest/manifest.go
+++ b/pkg/buildah/manifest/manifest.go
@@ -33,10 +33,10 @@ func (c *CommandArgs) GetCmds() ([]*exec.Cmd, error) {
 
 	// TODO replace with actual manifest commands. Currently is just testing that credentials work.
 	cmds = append(cmds,
-		exec.Command(common.BuildahCmd, "manifest", "create", "public.ecr.aws/kanopy/buildah-plugin:multiarchtest2"),
-		exec.Command(common.BuildahCmd, "manifest", "add", "public.ecr.aws/kanopy/buildah-plugin:multiarchtest2", "public.ecr.aws/kanopy/buildah-plugin:git-3afa39c-arm64"),
-		exec.Command(common.BuildahCmd, "manifest", "add", "public.ecr.aws/kanopy/buildah-plugin:multiarchtest2", "public.ecr.aws/kanopy/buildah-plugin:git-3afa39c-amd64"),
-		exec.Command(common.BuildahCmd, "manifest", "push", "--all", "public.ecr.aws/kanopy/buildah-plugin:multiarchtest2"),
+		exec.Command(common.BuildahCmd, "manifest", "create", "--storage-driver=vfs", "public.ecr.aws/kanopy/buildah-plugin:multiarchtest2"),
+		exec.Command(common.BuildahCmd, "manifest", "add", "--storage-driver=vfs", "public.ecr.aws/kanopy/buildah-plugin:multiarchtest2", "public.ecr.aws/kanopy/buildah-plugin:git-3afa39c-arm64"),
+		exec.Command(common.BuildahCmd, "manifest", "add", "--storage-driver=vfs", "public.ecr.aws/kanopy/buildah-plugin:multiarchtest2", "public.ecr.aws/kanopy/buildah-plugin:git-3afa39c-amd64"),
+		exec.Command(common.BuildahCmd, "manifest", "push", "--storage-driver=vfs", "--all", "public.ecr.aws/kanopy/buildah-plugin:multiarchtest2"),
 	)
 
 	return cmds, nil

--- a/pkg/buildah/manifest/manifest.go
+++ b/pkg/buildah/manifest/manifest.go
@@ -31,7 +31,7 @@ func (c *CommandArgs) GetCmds() ([]*exec.Cmd, error) {
 		return cmds, nil
 	}
 
-	// TODO replace with actual manifest commands. Currently is just for testing credentials work.
+	// TODO replace with actual manifest commands. Currently is just testing that credentials work.
 	cmds = append(cmds,
 		exec.Command(common.BuildahCmd, "pull", c.Sources[0]),
 	)

--- a/pkg/docker/config.go
+++ b/pkg/docker/config.go
@@ -1,0 +1,34 @@
+package docker
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+type (
+	Auth struct {
+		Auth string `json:"auth"`
+	}
+
+	Config struct {
+		Auths       map[string]Auth   `json:"auths"`
+		CredHelpers map[string]string `json:"credHelpers"`
+	}
+)
+
+func NewConfig() *Config {
+	return &Config{
+		Auths:       map[string]Auth{},
+		CredHelpers: map[string]string{},
+	}
+}
+
+func (c *Config) SetAuth(registry, username, password string) {
+	authBytes := []byte(fmt.Sprintf("%s:%s", username, password))
+	encodedString := base64.StdEncoding.EncodeToString(authBytes)
+	c.Auths[registry] = Auth{Auth: encodedString}
+}
+
+func (c *Config) SetCredHelper(registry, helper string) {
+	c.CredHelpers[registry] = helper
+}

--- a/pkg/docker/config_test.go
+++ b/pkg/docker/config_test.go
@@ -1,0 +1,27 @@
+package docker
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestConfig(t *testing.T) {
+	testRegistry := "public.ecr.aws"
+
+	c := NewConfig()
+
+	c.SetAuth(testRegistry, "test", "password")
+	c.SetCredHelper(testRegistry, "ecr-login")
+
+	bytes, err := json.Marshal(c)
+	if err != nil {
+		t.Error("json marshal failed")
+	}
+
+	want := `{"auths":{"public.ecr.aws":{"auth":"dGVzdDpwYXNzd29yZA=="}},"credHelpers":{"public.ecr.aws":"ecr-login"}}`
+	got := string(bytes)
+
+	if want != got {
+		t.Errorf("unexpected json output:\n  want: %s\n   got: %s", want, got)
+	}
+}

--- a/pkg/ecr/auth.go
+++ b/pkg/ecr/auth.go
@@ -1,0 +1,51 @@
+package ecr
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/kanopy-platform/buildah-plugin/pkg/docker"
+)
+
+const (
+	accessKeyEnv string = "AWS_ACCESS_KEY_ID"
+	secretKeyEnv string = "AWS_SECRET_ACCESS_KEY"
+)
+
+func CreateDockerConfig(accessKey, secretKey, registry string) (*docker.Config, error) {
+	var errs []error
+
+	if accessKey == "" {
+		errs = append(errs, fmt.Errorf("access_key must be specified"))
+	}
+
+	if secretKey == "" {
+		errs = append(errs, fmt.Errorf("secret_key must be specified"))
+	}
+
+	if registry == "" {
+		errs = append(errs, fmt.Errorf("registry must be specified"))
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+
+	dockerConfig := docker.NewConfig()
+
+	err := os.Setenv(accessKeyEnv, accessKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set %s environment variable: %v", accessKeyEnv, err)
+	}
+
+	err = os.Setenv(secretKeyEnv, secretKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set %s environment variable: %v", secretKeyEnv, err)
+	}
+
+	// uses the amazon-ecr-credential-helper credential helper
+	dockerConfig.SetCredHelper(registry, "ecr-login")
+
+	return dockerConfig, nil
+}

--- a/pkg/ecr/auth.go
+++ b/pkg/ecr/auth.go
@@ -44,7 +44,7 @@ func CreateDockerConfig(accessKey, secretKey, registry string) (*docker.Config, 
 		return nil, fmt.Errorf("failed to set %s environment variable: %v", secretKeyEnv, err)
 	}
 
-	// uses the amazon-ecr-credential-helper credential helper
+	// uses the amazon-ecr-credential-helper
 	dockerConfig.SetCredHelper(registry, "ecr-login")
 
 	return dockerConfig, nil

--- a/pkg/ecr/auth_test.go
+++ b/pkg/ecr/auth_test.go
@@ -1,0 +1,47 @@
+package ecr
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kanopy-platform/buildah-plugin/pkg/docker"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateDockerConfig(t *testing.T) {
+	t.Parallel()
+
+	testDockerConfig := docker.NewConfig()
+	testDockerConfig.SetCredHelper("hello.com", "ecr-login")
+
+	tests := map[string]struct {
+		accessKey string
+		secretKey string
+		registry  string
+		want      *docker.Config
+		wantErr   bool
+	}{
+		"missing accessKey, secretKey, registry": {
+			wantErr: true,
+		},
+		"successful": {
+			accessKey: "access",
+			secretKey: "secret",
+			registry:  "hello.com",
+			want:      testDockerConfig,
+		},
+	}
+
+	for name, test := range tests {
+		t.Log(name)
+
+		result, err := CreateDockerConfig(test.accessKey, test.secretKey, test.registry)
+		assert.Equal(t, test.want, result)
+		assert.Equal(t, test.wantErr, err != nil)
+
+		if !test.wantErr {
+			assert.Equal(t, test.accessKey, os.Getenv(accessKeyEnv))
+			assert.Equal(t, test.secretKey, os.Getenv(secretKeyEnv))
+		}
+	}
+}


### PR DESCRIPTION
Adds the `amazon-ecr-credential-helper` to the container image.
ECR `access-key` and `secret-key` will be set as environment variables, and the credential helper will do the work when executing any buildah command. `buildah login` is not needed.

### Testing
I spun up minikube to have a working registry.example.com

```
make local-push

docker run --rm --security-opt seccomp=/Users/yuzhou.liu/Downloads/work/buildah/seccomp.json --rm -e PLUGIN_MANIFEST="{\"sources\":[\"a\"],\"targets\":[\"1\"]}" -e PLUGIN_ACCESS_KEY="public_ecr_key" -e PLUGIN_SECRET_KEY="public_ecr_secret" -e PLUGIN_REGISTRY="public.ecr.aws" registry.example.com/buildah-plugin:latest
```

The seccomp.json is from [here](https://src.fedoraproject.org/rpms/containers-common/raw/main/f/seccomp.json) and is needed for docker because of [this](https://github.com/containers/buildah/issues/1901#issuecomment-540546758)

Alternatively, testing with podman, you don't need seccomp.json
```
podman run --rm -e PLUGIN_MANIFEST="{\"sources\":[\"a\"],\"targets\":[\"1\"]}" -e PLUGIN_ACCESS_KEY="public_ecr_key" -e PLUGIN_SECRET_KEY="public_ecr_secret" -e PLUGIN_REGISTRY="public.ecr.aws" registry.example.com/buildah-plugin:latest
``` 

I'll post more details on how to test in slack