### PR TITLE
Add buildah manifest commands

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -9,6 +9,7 @@ import (
 
 	buildversion "github.com/kanopy-platform/buildah-plugin/internal/version"
 	"github.com/kanopy-platform/buildah-plugin/pkg/buildah"
+	"github.com/kanopy-platform/buildah-plugin/pkg/buildah/manifest"
 	"github.com/kanopy-platform/buildah-plugin/pkg/ecr"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -69,6 +70,10 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 
 	buildah := buildah.Buildah{
 		Repo: viper.GetString("repo"),
+		Manifest: manifest.CommandArgs{
+			Registry: viper.GetString("registry"),
+			Repo:     viper.GetString("repo"),
+		},
 	}
 
 	var errs error

--- a/pkg/buildah/manifest/manifest_test.go
+++ b/pkg/buildah/manifest/manifest_test.go
@@ -1,8 +1,10 @@
 package manifest
 
 import (
+	"os/exec"
 	"testing"
 
+	"github.com/kanopy-platform/buildah-plugin/pkg/buildah/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -49,5 +51,39 @@ func TestIsManifestCmd(t *testing.T) {
 		result, err := test.args.isManifestCmd()
 		assert.Equal(t, test.wantResult, result)
 		assert.Equal(t, test.wantErr, err != nil)
+	}
+}
+
+func TestManifestCommands(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		sources  []string
+		targets  []string
+		wantCmds []*exec.Cmd
+	}{
+		"multiple sources, multiple targets": {
+			sources: []string{"a", "b"},
+			targets: []string{"1", "2"},
+			wantCmds: []*exec.Cmd{
+				// target 1
+				exec.Command(common.BuildahCmd, manifestCommand, "create", storageDriverOptionVfs, "1"),
+				exec.Command(common.BuildahCmd, manifestCommand, "add", storageDriverOptionVfs, "1", "a"),
+				exec.Command(common.BuildahCmd, manifestCommand, "add", storageDriverOptionVfs, "1", "b"),
+				exec.Command(common.BuildahCmd, manifestCommand, "push", storageDriverOptionVfs, "--all", "1"),
+				// target 2
+				exec.Command(common.BuildahCmd, manifestCommand, "create", storageDriverOptionVfs, "2"),
+				exec.Command(common.BuildahCmd, manifestCommand, "add", storageDriverOptionVfs, "2", "a"),
+				exec.Command(common.BuildahCmd, manifestCommand, "add", storageDriverOptionVfs, "2", "b"),
+				exec.Command(common.BuildahCmd, manifestCommand, "push", storageDriverOptionVfs, "--all", "2"),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Log(name)
+
+		result := manifestCommands(test.sources, test.targets)
+		assert.Equal(t, test.wantCmds, result)
 	}
 }

--- a/pkg/buildah/manifest/manifest_test.go
+++ b/pkg/buildah/manifest/manifest_test.go
@@ -23,22 +23,28 @@ func TestIsManifestCmd(t *testing.T) {
 		},
 		"all required args exist": {
 			args: CommandArgs{
-				Sources: []string{"a"},
-				Targets: []string{"b"},
+				Registry: "a",
+				Repo:     "b",
+				Sources:  []string{"a"},
+				Targets:  []string{"b"},
 			},
 			wantResult: true,
 			wantErr:    false,
 		},
 		"missing sources": {
 			args: CommandArgs{
-				Targets: []string{"b"},
+				Registry: "a",
+				Repo:     "b",
+				Targets:  []string{"b"},
 			},
 			wantResult: true,
 			wantErr:    true,
 		},
 		"missing targets": {
 			args: CommandArgs{
-				Sources: []string{"a"},
+				Registry: "a",
+				Repo:     "b",
+				Sources:  []string{"a"},
 			},
 			wantResult: true,
 			wantErr:    true,
@@ -58,24 +64,27 @@ func TestManifestCommands(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		sources  []string
-		targets  []string
-		wantCmds []*exec.Cmd
+		commandArgs CommandArgs
+		wantCmds    []*exec.Cmd
 	}{
 		"multiple sources, multiple targets": {
-			sources: []string{"a", "b"},
-			targets: []string{"1", "2"},
+			commandArgs: CommandArgs{
+				Registry: "public.ecr.aws",
+				Repo:     "devops",
+				Sources:  []string{"a", "b"},
+				Targets:  []string{"1", "2"},
+			},
 			wantCmds: []*exec.Cmd{
 				// target 1
-				exec.Command(common.BuildahCmd, manifestCommand, "create", storageDriverOptionVfs, "1"),
-				exec.Command(common.BuildahCmd, manifestCommand, "add", storageDriverOptionVfs, "1", "a"),
-				exec.Command(common.BuildahCmd, manifestCommand, "add", storageDriverOptionVfs, "1", "b"),
-				exec.Command(common.BuildahCmd, manifestCommand, "push", storageDriverOptionVfs, "--all", "1"),
+				exec.Command(common.BuildahCmd, manifestCommand, "create", storageDriverOptionVfs, "public.ecr.aws/devops:1"),
+				exec.Command(common.BuildahCmd, manifestCommand, "add", storageDriverOptionVfs, "public.ecr.aws/devops:1", "public.ecr.aws/devops:a"),
+				exec.Command(common.BuildahCmd, manifestCommand, "add", storageDriverOptionVfs, "public.ecr.aws/devops:1", "public.ecr.aws/devops:b"),
+				exec.Command(common.BuildahCmd, manifestCommand, "push", storageDriverOptionVfs, "--all", "public.ecr.aws/devops:1"),
 				// target 2
-				exec.Command(common.BuildahCmd, manifestCommand, "create", storageDriverOptionVfs, "2"),
-				exec.Command(common.BuildahCmd, manifestCommand, "add", storageDriverOptionVfs, "2", "a"),
-				exec.Command(common.BuildahCmd, manifestCommand, "add", storageDriverOptionVfs, "2", "b"),
-				exec.Command(common.BuildahCmd, manifestCommand, "push", storageDriverOptionVfs, "--all", "2"),
+				exec.Command(common.BuildahCmd, manifestCommand, "create", storageDriverOptionVfs, "public.ecr.aws/devops:2"),
+				exec.Command(common.BuildahCmd, manifestCommand, "add", storageDriverOptionVfs, "public.ecr.aws/devops:2", "public.ecr.aws/devops:a"),
+				exec.Command(common.BuildahCmd, manifestCommand, "add", storageDriverOptionVfs, "public.ecr.aws/devops:2", "public.ecr.aws/devops:b"),
+				exec.Command(common.BuildahCmd, manifestCommand, "push", storageDriverOptionVfs, "--all", "public.ecr.aws/devops:2"),
 			},
 		},
 	}
@@ -83,7 +92,7 @@ func TestManifestCommands(t *testing.T) {
 	for name, test := range tests {
 		t.Log(name)
 
-		result := manifestCommands(test.sources, test.targets)
+		result := test.commandArgs.manifestCommands()
 		assert.Equal(t, test.wantCmds, result)
 	}
 }

--- a/pkg/buildah/version/version.go
+++ b/pkg/buildah/version/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	Command = "version"
+	versionCommand = "version"
 )
 
 type (
@@ -19,7 +19,7 @@ type (
 func (c *CommandArgs) GetCmds() []*exec.Cmd {
 	if c.Print {
 		return []*exec.Cmd{
-			exec.Command(common.BuildahCmd, Command),
+			exec.Command(common.BuildahCmd, versionCommand),
 		}
 	}
 

--- a/pkg/buildah/version/version_test.go
+++ b/pkg/buildah/version/version_test.go
@@ -26,7 +26,7 @@ func TestGetCmds(t *testing.T) {
 			args: CommandArgs{
 				Print: true,
 			},
-			wantCmds: []string{fmt.Sprintf("%s %s", common.BuildahCmd, Command)},
+			wantCmds: []string{fmt.Sprintf("%s %s", common.BuildahCmd, versionCommand)},
 		},
 	}
 


### PR DESCRIPTION
Generates the `buildah manifest` commands based off the input sources and targets.

### Testing
This was tested to be working in drone using this [pipeline](https://github.com/yuzhouliu9/web-app-go/blob/main/.drone.yml#L110-L115) which takes the amd64 and arm64 images from previous steps and creates a single image.
The single image is later deployed on amd64 and arm64 nodes and verified to work on both.